### PR TITLE
Origin Metadata

### DIFF
--- a/src/SessionKeyRegistry.sol
+++ b/src/SessionKeyRegistry.sol
@@ -5,6 +5,8 @@ contract SessionKeyRegistry {
     mapping(address user => mapping(address signer => mapping(bytes32 permission => uint256))) public
         authorizationExpiry;
 
+    event AuthorizationsUpdated(address indexed identity, address indexed signer, bytes32[] permissions, string origin);
+
     function _setAuthorizations(address signer, uint256 expiry, bytes32[] calldata permissions) internal {
         mapping(bytes32 => uint256) storage permissionExpiry = authorizationExpiry[msg.sender][signer];
         for (uint256 i = 0; i < permissions.length; i++) {
@@ -16,9 +18,11 @@ contract SessionKeyRegistry {
      * @notice Caller revokes from the signer the specified permissions
      * @param signer the authorized account
      * @param permissions the scope of authority to revoke from the signer
+     * @param origin indicates what app prompted this revocation
      */
-    function revoke(address signer, bytes32[] calldata permissions) external {
+    function revoke(address signer, bytes32[] calldata permissions, string calldata origin) external {
         _setAuthorizations(signer, 0, permissions);
+        emit AuthorizationsUpdated(msg.sender, signer, permissions, origin);
     }
 
     /**
@@ -26,9 +30,11 @@ contract SessionKeyRegistry {
      * @param signer the account authorized
      * @param expiry when the authorization ends
      * @param permissions the scope of authority granted to the signer
+     * @param origin indicates what app prompted this authorization
      */
-    function login(address signer, uint256 expiry, bytes32[] calldata permissions) external {
+    function login(address signer, uint256 expiry, bytes32[] calldata permissions, string calldata origin) external {
         _setAuthorizations(signer, expiry, permissions);
+        emit AuthorizationsUpdated(msg.sender, signer, permissions, origin);
     }
 
     /**
@@ -36,9 +42,16 @@ contract SessionKeyRegistry {
      * @param signer the account authorized
      * @param expiry when the authorization ends
      * @param permissions the scope of authority granted to the signer
+     * @param origin indicates what app prompted this authorization
      */
-    function loginAndFund(address payable signer, uint256 expiry, bytes32[] calldata permissions) external payable {
+    function loginAndFund(
+        address payable signer,
+        uint256 expiry,
+        bytes32[] calldata permissions,
+        string calldata origin
+    ) external payable {
         _setAuthorizations(signer, expiry, permissions);
+        emit AuthorizationsUpdated(msg.sender, signer, permissions, origin);
         signer.transfer(msg.value);
     }
 }

--- a/test/SessionKeyRegistry.t.sol
+++ b/test/SessionKeyRegistry.t.sol
@@ -12,6 +12,7 @@ contract SessionKeyRegistryTest is Test {
     bytes32 private constant PERMISSION1 = 0x1111111111111111111111111111111111111111111111111111111111111111;
     bytes32 private constant PERMISSION2 = 0x2222222222222222222222222222222222222222222222222222222222222222;
     bytes32 private constant PERMISSION3 = 0x3333333333333333333333333333333333333333333333333333333333333333;
+    string constant ORIGIN = "SessionKeyRegistryTest";
 
     uint256 private constant DAY_SECONDS = 1 days;
 
@@ -27,14 +28,14 @@ contract SessionKeyRegistryTest is Test {
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION3), 0);
 
         uint256 expiry = block.timestamp + DAY_SECONDS;
-        registry.loginAndFund{value: 1 ether}(SIGNER_ONE, expiry, permissions);
+        registry.loginAndFund{value: 1 ether}(SIGNER_ONE, expiry, permissions, ORIGIN);
 
         assertEq(SIGNER_ONE.balance, 1 ether);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION1), expiry);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION2), expiry);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION3), expiry);
 
-        registry.revoke(SIGNER_ONE, permissions);
+        registry.revoke(SIGNER_ONE, permissions, ORIGIN);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION1), 0);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION2), 0);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_ONE, PERMISSION3), 0);
@@ -51,13 +52,13 @@ contract SessionKeyRegistryTest is Test {
 
         uint256 expiry = block.timestamp + 4 * DAY_SECONDS;
 
-        registry.login(SIGNER_TWO, expiry, permissions);
+        registry.login(SIGNER_TWO, expiry, permissions, ORIGIN);
 
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION1), expiry);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION2), 0);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION3), expiry);
 
-        registry.revoke(SIGNER_TWO, permissions);
+        registry.revoke(SIGNER_TWO, permissions, ORIGIN);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION1), 0);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION2), 0);
         assertEq(registry.authorizationExpiry(address(this), SIGNER_TWO, PERMISSION3), 0);


### PR DESCRIPTION

Reviewer @hugomrdias @rvagg
Closes https://github.com/FilOzone/SessionKeyRegistry/issues/4
We want to be able to query session key authorizations for a user so we can revoke them.
We also want to be able to display some context about which app might have prompted the user to authorize the key.
So I introduce an event log that we can query in order to get all sessions for a user.
I don't index the signer though it could be used to check if the key was previously authorized by another user, which could be a red flag or noise.
Since anyone can approve any key, someone else approving your key is likely to be spam or even a scam.
An alternative design would emit a separate log for each permission and index the permissions but I think that would be redundant and I don't think it will be a common query.
If someone does need an index of all permissions, they can build it from this index, instead of building it into the chain.
#### Changes
* add origin metadata to calldata
* emit AuthorizationsUpdated log